### PR TITLE
Change sources from ssh to https as these are public repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,7 +4127,7 @@ checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 [[package]]
 name = "mp2_common"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#c42994349a27db7ec485bce862d3b2bb902036e3"
+source = "git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#9f281950ca365666ff9b2b08fe90b403d50de75a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "mp2_v1"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#c42994349a27db7ec485bce862d3b2bb902036e3"
+source = "git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#9f281950ca365666ff9b2b08fe90b403d50de75a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4173,7 +4173,7 @@ dependencies = [
  "plonky2_crypto",
  "plonky2_ecgfp5",
  "rand",
- "recursion_framework 0.1.0 (git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main)",
+ "recursion_framework 0.1.0 (git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main)",
  "rlp",
  "ryhope",
  "serde",
@@ -4565,7 +4565,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4573,7 +4573,7 @@ dependencies = [
 [[package]]
 name = "parsil"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#c42994349a27db7ec485bce862d3b2bb902036e3"
+source = "git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#9f281950ca365666ff9b2b08fe90b403d50de75a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5260,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "recursion_framework"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#c42994349a27db7ec485bce862d3b2bb902036e3"
+source = "git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#9f281950ca365666ff9b2b08fe90b403d50de75a"
 dependencies = [
  "anyhow",
  "log",
@@ -5292,15 +5292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0020ec469b096d56edb1ed0f0f141d957863302170f8d9c4bfda1a12969e5969"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5833,7 +5824,7 @@ dependencies = [
 [[package]]
 name = "ryhope"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#c42994349a27db7ec485bce862d3b2bb902036e3"
+source = "git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#9f281950ca365666ff9b2b08fe90b403d50de75a"
 dependencies = [
  "anyhow",
  "bb8",
@@ -7225,7 +7216,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "verifiable-db"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#c42994349a27db7ec485bce862d3b2bb902036e3"
+source = "git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main#9f281950ca365666ff9b2b08fe90b403d50de75a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7239,7 +7230,7 @@ dependencies = [
  "plonky2_ecdsa",
  "plonky2_ecgfp5",
  "rand",
- "recursion_framework 0.1.0 (git+ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main)",
+ "recursion_framework 0.1.0 (git+https://github.com/Lagrange-Labs/mapreduce-plonky2.git?branch=main)",
  "ryhope",
  "serde",
 ]
@@ -7414,11 +7405,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "wasite",
  "web-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ resolver = "2"
 members = ["lgn-auth", "lgn-messages", "lgn-provers", "lgn-worker"]
 
 [workspace.dependencies]
-mp2_common = { git = "ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
-mp2_v1 = { git = "ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
-parsil = { git = "ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
-verifiable-db = { git = "ssh://git@github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
+mp2_common = { git = "https://github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
+mp2_v1 = { git = "https://github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
+parsil = { git = "https://github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
+verifiable-db = { git = "https://github.com/Lagrange-Labs/mapreduce-plonky2.git", branch = "main" }
 
 [patch.crates-io]
 plonky2 = { git = "https://github.com/Lagrange-Labs/plonky2", branch = "upstream" }


### PR DESCRIPTION
This allows automated build systems to clone repositories without requiring ssh-agent to be present.