### PR TITLE
feat: add versioning for request messages

### DIFF
--- a/lgn-provers/src/provers/mod.rs
+++ b/lgn-provers/src/provers/mod.rs
@@ -1,5 +1,5 @@
-use lgn_messages::types::MessageEnvelope;
 use lgn_messages::types::MessageReplyEnvelope;
+use lgn_messages::types::RequestVersioned;
 
 pub mod v1;
 
@@ -10,6 +10,6 @@ pub mod v1;
 pub trait LgnProver {
     fn run(
         &self,
-        envelope: MessageEnvelope,
+        envelope: RequestVersioned,
     ) -> anyhow::Result<MessageReplyEnvelope>;
 }

--- a/lgn-provers/src/provers/v1/groth16/dummy_prover.rs
+++ b/lgn-provers/src/provers/v1/groth16/dummy_prover.rs
@@ -1,9 +1,9 @@
 use anyhow::bail;
 use lgn_messages::types::v1::groth16::keys::ProofKey;
-use lgn_messages::types::MessageEnvelope;
 use lgn_messages::types::MessageReplyEnvelope;
 use lgn_messages::types::ProofCategory;
 use lgn_messages::types::ReplyType;
+use lgn_messages::types::RequestVersioned;
 use lgn_messages::types::TaskType;
 use lgn_messages::types::WorkerReply;
 
@@ -18,17 +18,18 @@ pub struct Groth16DummyProver;
 impl LgnProver for Groth16DummyProver {
     fn run(
         &self,
-        envelope: MessageEnvelope,
+        envelope: RequestVersioned,
     ) -> anyhow::Result<MessageReplyEnvelope> {
-        let query_id = envelope.query_id.clone();
-        let task_id = envelope.task_id.clone();
+        let query_id = envelope.query_id();
+        let task_id = envelope.task_id();
         if let TaskType::V1Groth16(task) = envelope.inner() {
             let key = ProofKey(query_id.to_string()).to_string();
             let proof = dummy_proof(PROOF_SIZE);
             let reply =
                 WorkerReply::new(task.chain_id, Some((key, proof)), ProofCategory::Querying);
             let reply_type = ReplyType::V1Groth16(reply);
-            let reply_envelope = MessageReplyEnvelope::new(query_id, task_id, reply_type);
+            let reply_envelope =
+                MessageReplyEnvelope::new(query_id.to_owned(), task_id.to_owned(), reply_type);
             Ok(reply_envelope)
         } else {
             bail!("Unexpected task: {:?}", envelope);

--- a/lgn-provers/src/provers/v1/groth16/task.rs
+++ b/lgn-provers/src/provers/v1/groth16/task.rs
@@ -1,16 +1,11 @@
-use std::time::Instant;
-
 use anyhow::bail;
-use anyhow::Context;
 use lgn_messages::types::v1::groth16::keys::ProofKey;
-use lgn_messages::types::MessageEnvelope;
 use lgn_messages::types::MessageReplyEnvelope;
 use lgn_messages::types::ProofCategory;
 use lgn_messages::types::ReplyType;
+use lgn_messages::types::RequestVersioned;
 use lgn_messages::types::TaskType;
 use lgn_messages::types::WorkerReply;
-use tracing::debug;
-use tracing::info;
 
 use super::euclid_prover::Groth16EuclidProver;
 use crate::provers::LgnProver;
@@ -18,51 +13,23 @@ use crate::provers::LgnProver;
 impl LgnProver for Groth16EuclidProver {
     fn run(
         &self,
-        envelope: MessageEnvelope,
+        envelope: RequestVersioned,
     ) -> anyhow::Result<MessageReplyEnvelope> {
-        let query_id = envelope.query_id.clone();
-        let task_id = envelope.task_id.clone();
+        let query_id = envelope.query_id();
+        let task_id = envelope.task_id();
+
         if let TaskType::V1Groth16(task) = envelope.inner() {
-            let proof = self.generate_proof(
-                &query_id,
-                &task_id,
-                task.revelation_proof.proof().as_slice(),
-            )?;
-            let reply = WorkerReply::new(task.chain_id, Some(proof), ProofCategory::Querying);
+            let key = ProofKey(query_id.to_string()).to_string();
+            let proof = self.prove(task.revelation_proof.proof().as_slice())?;
+
+            let reply =
+                WorkerReply::new(task.chain_id, Some((key, proof)), ProofCategory::Querying);
             let reply_type = ReplyType::V1Groth16(reply);
-            let reply_envelope = MessageReplyEnvelope::new(query_id, task_id, reply_type);
+            let reply_envelope =
+                MessageReplyEnvelope::new(query_id.to_owned(), task_id.to_owned(), reply_type);
             Ok(reply_envelope)
         } else {
             bail!("Unexpected task: {:?}", envelope);
         }
-    }
-}
-
-impl Groth16EuclidProver {
-    /// Generate the Groth proof.
-    fn generate_proof(
-        &self,
-        query_id: &str,
-        task_id: &str,
-        revelation: &[u8],
-    ) -> anyhow::Result<(String, Vec<u8>)> {
-        // Generate the Groth16 proof.
-        let now = Instant::now();
-        let key = ProofKey(query_id.to_string()).to_string();
-        let proof = self.prove(revelation).with_context(|| {
-            format!(
-                " Failed to generate the Groth16 proof: query_id = {query_id}, task_id = {task_id}"
-            )
-        })?;
-        debug!("Finish generating the Groth16 proof: query_id = {query_id}, task_id = {task_id}",);
-
-        info!(
-            time = now.elapsed().as_secs_f32(),
-            proof_type = "groth16",
-            "proof generation time: {:?}",
-            now.elapsed()
-        );
-
-        Ok((key, proof))
     }
 }

--- a/lgn-provers/src/provers/v1/preprocessing/dummy_prover.rs
+++ b/lgn-provers/src/provers/v1/preprocessing/dummy_prover.rs
@@ -3,10 +3,10 @@ use lgn_messages::types::v1::preprocessing::db_keys;
 use lgn_messages::types::v1::preprocessing::ext_keys;
 use lgn_messages::types::v1::preprocessing::WorkerTask;
 use lgn_messages::types::v1::preprocessing::WorkerTaskType;
-use lgn_messages::types::MessageEnvelope;
 use lgn_messages::types::MessageReplyEnvelope;
 use lgn_messages::types::ProofCategory;
 use lgn_messages::types::ReplyType;
+use lgn_messages::types::RequestVersioned;
 use lgn_messages::types::TaskType;
 use lgn_messages::types::WorkerReply;
 
@@ -21,30 +21,31 @@ pub struct PreprocessingDummyProver;
 impl LgnProver for PreprocessingDummyProver {
     fn run(
         &self,
-        envelope: MessageEnvelope,
+        envelope: RequestVersioned,
     ) -> anyhow::Result<MessageReplyEnvelope> {
-        let query_id = envelope.query_id.clone();
-        let task_id = envelope.task_id.clone();
-        if let TaskType::V1Preprocessing(task @ WorkerTask { chain_id, .. }) = &envelope.inner {
+        let query_id = envelope.query_id().to_owned();
+        let task_id = envelope.task_id().to_owned();
+        if let TaskType::V1Preprocessing(task @ WorkerTask { chain_id, .. }) = envelope.into_inner()
+        {
             let key = match &task.task_type {
                 WorkerTaskType::Extraction(_) => {
-                    let key: ext_keys::ProofKey = task.into();
+                    let key: ext_keys::ProofKey = (&task).into();
                     key.to_string()
                 },
                 WorkerTaskType::Database(_) => {
-                    let key: db_keys::ProofKey = task.into();
+                    let key: db_keys::ProofKey = (&task).into();
                     key.to_string()
                 },
             };
             let result = dummy_proof(PROOF_SIZE);
             let reply_type = ReplyType::V1Preprocessing(WorkerReply::new(
-                *chain_id,
+                chain_id,
                 Some((key, result)),
                 ProofCategory::Querying,
             ));
             Ok(MessageReplyEnvelope::new(query_id, task_id, reply_type))
         } else {
-            bail!("Unexpected task: {:?}", envelope);
+            bail!("Unexpected task. task_id: {}", task_id);
         }
     }
 }

--- a/lgn-provers/src/provers/v1/query/dummy_prover.rs
+++ b/lgn-provers/src/provers/v1/query/dummy_prover.rs
@@ -1,10 +1,10 @@
 use anyhow::bail;
 use lgn_messages::types::v1::query::keys::ProofKey;
 use lgn_messages::types::v1::query::WorkerTask;
-use lgn_messages::types::MessageEnvelope;
 use lgn_messages::types::MessageReplyEnvelope;
 use lgn_messages::types::ProofCategory;
 use lgn_messages::types::ReplyType;
+use lgn_messages::types::RequestVersioned;
 use lgn_messages::types::TaskType;
 use lgn_messages::types::WorkerReply;
 
@@ -19,16 +19,16 @@ pub struct QueryDummyProver;
 impl LgnProver for QueryDummyProver {
     fn run(
         &self,
-        envelope: MessageEnvelope,
+        envelope: RequestVersioned,
     ) -> anyhow::Result<MessageReplyEnvelope> {
-        let query_id = envelope.query_id.clone();
-        let task_id = envelope.task_id.clone();
+        let query_id = envelope.query_id().to_owned();
+        let task_id = envelope.task_id().to_owned();
 
-        if let TaskType::V1Query(ref task @ WorkerTask { chain_id, .. }) = envelope.inner {
+        if let TaskType::V1Query(ref task @ WorkerTask { chain_id, .. }) = envelope.inner() {
             let key: ProofKey = task.into();
             let result = dummy_proof(PROOF_SIZE);
             let reply_type = ReplyType::V1Query(WorkerReply::new(
-                chain_id,
+                *chain_id,
                 Some((key.to_string(), result)),
                 ProofCategory::Querying,
             ));

--- a/lgn-provers/src/provers/v1/query/task.rs
+++ b/lgn-provers/src/provers/v1/query/task.rs
@@ -23,8 +23,8 @@ impl LgnProver for QueryEuclidProver {
         &self,
         envelope: RequestVersioned,
     ) -> anyhow::Result<MessageReplyEnvelope> {
-        let query_id = envelope.query_id().clone();
-        let task_id = envelope.task_id().clone();
+        let query_id = envelope.query_id();
+        let task_id = envelope.task_id();
 
         if let TaskType::V1Query(ref task @ WorkerTask { chain_id, .. }) = envelope.inner() {
             let key: ProofKey = task.into();

--- a/lgn-worker/src/manager.rs
+++ b/lgn-worker/src/manager.rs
@@ -4,9 +4,9 @@ use std::panic::UnwindSafe;
 
 use anyhow::bail;
 use anyhow::Context;
-use lgn_messages::types::MessageEnvelope;
 use lgn_messages::types::MessageReplyEnvelope;
 use lgn_messages::types::ProverType;
+use lgn_messages::types::RequestVersioned;
 use lgn_messages::types::TaskDifficulty;
 use lgn_provers::provers::LgnProver;
 use tracing::info;
@@ -92,9 +92,9 @@ impl ProversManager {
     /// A message reply envelope containing the result of the proving task
     pub(crate) fn delegate_proving(
         &self,
-        envelope: MessageEnvelope,
+        envelope: RequestVersioned,
     ) -> anyhow::Result<MessageReplyEnvelope> {
-        let prover_type: ProverType = envelope.inner.to_prover_type();
+        let prover_type: ProverType = envelope.to_prover_type();
 
         match self.provers.get(&prover_type) {
             Some(prover) => prover.run(envelope),

--- a/lgn-worker/src/one-shot.rs
+++ b/lgn-worker/src/one-shot.rs
@@ -4,7 +4,7 @@
 use anyhow::*;
 use checksum::fetch_checksums;
 use clap::Parser;
-use lgn_messages::types::MessageEnvelope;
+use lgn_messages::types::RequestVersioned;
 use manager::ProversManager;
 use tracing::error;
 use tracing::level_filters::LevelFilter;
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
     let envelope = std::fs::read_to_string(&cli.input)
         .with_context(|| format!("failed to open `{}`", cli.input))
         .and_then(|content| {
-            serde_json::from_str::<MessageEnvelope>(&content).context("failed to parse input JSON")
+            serde_json::from_str::<RequestVersioned>(&content).context("failed to parse input JSON")
         })?;
 
     provers_manager


### PR DESCRIPTION
This is a backwards compatible message format. It adds a `version` field to the message, and fallbacks to the existing envelope as a default. This will allow to deploy a worker that supports the current in-flight messages and also a new format. The goal is to eventually phase out the legacy format (the one without a `version` field), and to add a version that doesn't need the S3 keys nor the hydratable attributes (the former is not needed here, but can't yet be removed because of backwards compatibility, the later is an artifact of how the messages are constructed, and it is not important for the worker, it also results in compilation warnings because of the macro use)