### PR TITLE
chore: make the default devenv worker large

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -10,7 +10,7 @@ let
 
   avsWorkerConfig = {
     worker = {
-      instance_type = "medium";
+      instance_type = "large";
     };
 
     avs = {


### PR DESCRIPTION
this is usually used for a dummy-worker